### PR TITLE
fix: set celery worker concurrency to 1

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     environment:
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
-    command: celery -A src.worker.celery worker --loglevel=info
+    command: celery -A src.worker.celery worker --loglevel=info --concurrency=1
 
   redis:
     image: redis:alpine


### PR DESCRIPTION
## Problem

The H200 server has 256 CPU cores. Celery's prefork concurrency defaults to CPU count, causing it to spawn 256 worker processes. Each process requires file descriptors for inter-process pipes (roughly 4+ fds per worker).

With the container's default ulimit (1024 file descriptors), this causes immediate crash:

```
OSError: [Errno 24] Too many open files
```

## Solution

Set `--concurrency=1` explicitly. The extensions worker only handles `process_space_creation`, so a single worker is sufficient.

## Testing

After merge, redeploy MantisAPI to verify the celery worker container starts successfully.